### PR TITLE
chore(repo): Added "files" attribute to package.json to limit size of publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0-11",
   "description": "Responsive React grid system built with styled-components",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepublish": "babel src -d dist",
     "lint": "./node_modules/.bin/eslint ./src",


### PR DESCRIPTION
### How does this PR make you feel (in animated GIF format)?
![https://media.giphy.com/media/tMPSeKEplOfK0/giphy.gif](https://media.giphy.com/media/tMPSeKEplOfK0/giphy.gif)


#### Please provide a summary of changes and any background context...
When publishing to NPM all files and folders where being published. This change will limit to only what is needed (`dist` folder).

---

### Technical Review
* Cant test locally, but by comments in [#9](https://github.com/GhostGroup/grid-styled/issues/9), I added the `dist` folder to `package.json`

