### PR TITLE
fix(box): memoize base element and is prop to persist component across renders

### DIFF
--- a/src/box.js
+++ b/src/box.js
@@ -19,9 +19,19 @@ class Box extends Component {
   };
 
   render() {
-    const {is, ...rest} = this.props;
-    const Base = styled(is)([], { boxSizing: "border-box" }, width, space, flex, order);
-    return <Base {...rest}/>;
+    const { is, ...rest } = this.props;
+    if (!this.base || this.is !== is) {
+      this.is = is;
+      this.base = styled(is)(
+        [],
+        { boxSizing: "border-box" },
+        width,
+        space,
+        flex,
+        order
+      );
+    }
+    return <this.base {...rest} />;
   }
 }
 

--- a/src/box.test.js
+++ b/src/box.test.js
@@ -4,7 +4,7 @@ import { shallow, mount } from "enzyme";
 import Box from "./box";
 
 describe("box", () => {
-  it("renders",() => {
+  it("renders", () => {
     const tree = shallow(<Box m={2} px={3} />);
     expect(tree).toMatchSnapshot();
   });
@@ -31,5 +31,21 @@ describe("box", () => {
       </Box>
     );
     expect(tree).toMatchSnapshot();
+  });
+
+  it("renders the same component when props change", () => {
+    class Component extends React.Component {
+      render() {
+        return (
+          <Box {...this.props}>
+            <div ref="childRef" />
+          </Box>
+        );
+      }
+    }
+    const tree = mount(<Component />);
+    const childRef = tree.ref("childRef");
+    tree.setProps({ value: "a new value" });
+    expect(tree.ref("childRef")).toBe(childRef);
   });
 });


### PR DESCRIPTION
### How does this PR make you feel (in animated GIF format)?
![](https://media.giphy.com/media/l46Cl0tMeGOdC6CCA/giphy.gif)

#### Prerequisites
- Is there any documentation that needs to be updated?

nope

#### Please provide a summary of changes and any background context...

All renders were returning a new element based on the change made to fix the `is` prop. This change memoizes the base component based on the is prop and returns that component again in render if already created.

---

### Technical Review
* [ ] Is there enough test coverage?
* Ask questions, have a conversation!


#### How should this be manually tested (any data/API considerations)?
