### PR TITLE
bug(box): Memoize box in outer scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ghostgroup/grid-styled",
-  "version": "2.0.0-11",
+  "version": "3.0.3",
   "description": "Responsive React grid system built with styled-components",
   "main": "dist/index.js",
   "files": [

--- a/src/__snapshots__/box.test.js.snap
+++ b/src/__snapshots__/box.test.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`box can be extended 1`] = `
-.c0 {
-  background-color: blue;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 100%;
@@ -14,6 +10,10 @@ exports[`box can be extended 1`] = `
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
+}
+
+.c0 {
+  background-color: blue;
 }
 
 @media screen and (min-width:40em) {

--- a/src/box.js
+++ b/src/box.js
@@ -7,6 +7,8 @@ const responsivePropType = oneOfType([number, string, array]);
 const flex = responsiveStyle("flex");
 const order = responsiveStyle("order");
 
+const BoxTypeMap = {};
+
 class Box extends Component {
   static propTypes = {
     ...propTypes,
@@ -20,9 +22,8 @@ class Box extends Component {
 
   render() {
     const { is, ...rest } = this.props;
-    if (!this.base || this.is !== is) {
-      this.is = is;
-      this.base = styled(is)(
+    if (!BoxTypeMap[is]) {
+      BoxTypeMap[is] = styled(is)(
         [],
         { boxSizing: "border-box" },
         width,
@@ -31,7 +32,8 @@ class Box extends Component {
         order
       );
     }
-    return <this.base {...rest} />;
+    const Comp = BoxTypeMap[is];
+    return <Comp {...rest} />;
   }
 }
 


### PR DESCRIPTION
### How does this PR make you feel (in animated GIF format)?
![shitshow](https://media.giphy.com/media/26FPy3QZQqGtDcrja/giphy.gif)

#### Prerequisites
- Is there any documentation that needs to be updated?
N/A
#### Please provide a summary of changes and any background context...

The `Box` component was memoizing permutations of itself from the `is` prop inside the component. On server renders, styled components checks if components are "new" and stores them in a map. Since new instances are created on every server render, the `Box` styled-components were always new. This was causing slow memory leaks in production.

---

### Technical Review
* [X] Is there enough test coverage?
* Ask questions, have a conversation!


#### How should this be manually tested (any data/API considerations)?
Tests pass or try out @ghostgroup/grid-styled@3.0.4-rc1