### PR TITLE
update readme for import tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm i @ghostgroup/grid-styled
 
 ```jsx
 import React from 'react'
-import { Flex, Box } from 'grid-styled'
+import { Flex, Box } from '@ghostgroup/grid-styled'
 
 const App = () => (
   <Flex>


### PR DESCRIPTION
to importing  ```from '@ghostgroup/grid-styled'```, 

I believe ```from 'grid-styled'``` is from pre fork